### PR TITLE
Override deletion protection on instance namespace deletion

### DIFF
--- a/config/controller/cluster-role.yaml
+++ b/config/controller/cluster-role.yaml
@@ -19,3 +19,12 @@ rules:
       - objects
     verbs:
       - delete
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - update
+      - list
+      - watch

--- a/controller/postgres/deletion_protection.go
+++ b/controller/postgres/deletion_protection.go
@@ -112,10 +112,15 @@ func getPatchObjectFinalizer(log logr.Logger, inst client.Object, op jsonOp) (cl
 
 	log.V(1).Info("Index size", "size", index, "found finalizers", inst.GetFinalizers())
 
+	strIndex := strconv.Itoa(index)
+	if op == opAdd {
+		strIndex = "-"
+	}
+
 	patchOps := []jsonpatch{
 		{
 			Op:    op,
-			Path:  "/metadata/finalizers/" + strconv.Itoa(index),
+			Path:  "/metadata/finalizers/" + strIndex,
 			Value: finalizerName,
 		},
 	}

--- a/controller/postgres/deletion_protection_test.go
+++ b/controller/postgres/deletion_protection_test.go
@@ -3,15 +3,16 @@ package postgres
 import (
 	"context"
 	"encoding/json"
+	"strconv"
+	"testing"
+	"time"
+
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	v1 "github.com/vshn/component-appcat/apis/vshn/v1"
 	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strconv"
-	"testing"
-	"time"
 )
 
 var currentTimeKey = "now"
@@ -237,7 +238,10 @@ func getXVSHNPostgreSQL(addFinalizer bool, deletedTime *time.Time) v1.XVSHNPostg
 }
 
 func getPatch(op jsonOp) client.Patch {
+	strIndex := strconv.Itoa(0)
 	if op == opAdd {
+		strIndex = "-"
+	}
 	patchOps := []jsonpatch{
 		{
 			Op:    op,

--- a/controller/postgres/deletion_protection_test.go
+++ b/controller/postgres/deletion_protection_test.go
@@ -361,7 +361,10 @@ func Test_instanceNamespaceDeleted(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			// Given
-			fclient := fake.NewFakeClientWithScheme(s, &tt.instance, &tt.namespace)
+			fclient := fake.NewClientBuilder().
+				WithScheme(s).
+				WithRuntimeObjects(&tt.instance, &tt.namespace).
+				Build()
 			logger := logr.Discard()
 
 			// When

--- a/controller/postgres/deletion_protection_test.go
+++ b/controller/postgres/deletion_protection_test.go
@@ -237,10 +237,11 @@ func getXVSHNPostgreSQL(addFinalizer bool, deletedTime *time.Time) v1.XVSHNPostg
 }
 
 func getPatch(op jsonOp) client.Patch {
+	if op == opAdd {
 	patchOps := []jsonpatch{
 		{
 			Op:    op,
-			Path:  "/metadata/finalizers/" + strconv.Itoa(0),
+			Path:  "/metadata/finalizers/" + strIndex,
 			Value: finalizerName,
 		},
 	}

--- a/controller/postgres/reconciler.go
+++ b/controller/postgres/reconciler.go
@@ -82,7 +82,11 @@ func (p *XPostgreSQLDeletionProtectionReconciler) deletePostgresDB(ctx context.C
 		},
 	}
 
-	return p.Delete(ctx, o)
+	err := p.Delete(ctx, o)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controller/postgres/reconciler.go
+++ b/controller/postgres/reconciler.go
@@ -41,7 +41,7 @@ func (p *XPostgreSQLDeletionProtectionReconciler) Reconcile(ctx context.Context,
 		log.Info("Deleting database")
 		err = p.deletePostgresDB(ctx, inst)
 		if err != nil {
-			return ctrl.Result{}, err
+			return ctrl.Result{RequeueAfter: requeueTime, Requeue: true}, err
 		}
 	}
 

--- a/controller/postgres/reconciler.go
+++ b/controller/postgres/reconciler.go
@@ -2,12 +2,16 @@ package postgres
 
 import (
 	"context"
+
 	xkube "github.com/crossplane-contrib/provider-kubernetes/apis/object/v1alpha1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	vshnv1 "github.com/vshn/component-appcat/apis/vshn/v1"
+
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logging "sigs.k8s.io/controller-runtime/pkg/log"
@@ -48,6 +52,8 @@ func (p *XPostgreSQLDeletionProtectionReconciler) Reconcile(ctx context.Context,
 }
 
 func (p *XPostgreSQLDeletionProtectionReconciler) handleDeletionProtection(ctx context.Context, inst *vshnv1.XVSHNPostgreSQL) error {
+	log := logging.FromContext(ctx, "namespace", inst.GetNamespace(), "instance", inst.GetName())
+
 	protectionEnabled := inst.Spec.Parameters.Backup.DeletionProtection
 	retention := inst.Spec.Parameters.Backup.DeletionRetention
 	baseObj := &vshnv1.XVSHNPostgreSQL{
@@ -63,10 +69,32 @@ func (p *XPostgreSQLDeletionProtectionReconciler) handleDeletionProtection(ctx c
 		return errors.Wrap(err, "cannot return patch operation object")
 	}
 
+	overridePatch, err := getInstanceNamespaceOverride(ctx, inst, protectionEnabled, p.Client)
+	if err != nil {
+		return errors.Wrap(err, "can't determine patch for namespace override")
+	}
+
+	if overridePatch != nil {
+		patch = overridePatch
+	}
+
 	if patch != nil {
-		if err = p.Patch(ctx, baseObj, patch); err != nil && !apierrors.IsNotFound(err) {
-			return errors.Wrap(err, "could not patch object")
+
+		errorFunc := func(err error) bool {
+			return err != nil && !apierrors.IsNotFound(err)
 		}
+
+		// Unfortunately patches just return generic errors if you patch something that has been modified.
+		// So we just retry a few times before actually logging and error.
+		err := retry.OnError(retry.DefaultBackoff, errorFunc, func() error {
+			log.V(1).Info("Trying to patch the object")
+			return p.Patch(ctx, baseObj, patch)
+		})
+
+		if err != nil {
+			return err
+		}
+
 	}
 
 	return nil
@@ -93,5 +121,6 @@ func (p *XPostgreSQLDeletionProtectionReconciler) deletePostgresDB(ctx context.C
 func (p *XPostgreSQLDeletionProtectionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vshnv1.XVSHNPostgreSQL{}).
+		Owns(&corev1.Namespace{}).
 		Complete(p)
 }

--- a/controller/postgres/reconciler_test.go
+++ b/controller/postgres/reconciler_test.go
@@ -242,7 +242,10 @@ func Test_Reconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 
 			// GIVEN
-			fclient := fake.NewFakeClientWithScheme(s, &tc.inst, &tc.instanceNamespace)
+			fclient := fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(&tc.inst, &tc.instanceNamespace).
+				Build()
 			reconciler := XPostgreSQLDeletionProtectionReconciler{
 				Client: fclient,
 			}

--- a/controller/postgres/reconciler_test.go
+++ b/controller/postgres/reconciler_test.go
@@ -2,6 +2,9 @@ package postgres
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/vshn/appcat-apiserver/test/mocks"
@@ -10,8 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"testing"
-	"time"
 )
 
 func Test_Reconcile(t *testing.T) {
@@ -45,7 +46,7 @@ func Test_Reconcile(t *testing.T) {
 					},
 				},
 			},
-			getInstanceTimes:    1,
+			getInstanceTimes:    2,
 			patchInstanceTimes:  1,
 			deleteInstanceTimes: 0,
 			expectedResult: ctrl.Result{
@@ -74,7 +75,7 @@ func Test_Reconcile(t *testing.T) {
 					},
 				},
 			},
-			getInstanceTimes:    1,
+			getInstanceTimes:    2,
 			patchInstanceTimes:  0,
 			deleteInstanceTimes: 0,
 			expectedResult: ctrl.Result{
@@ -105,7 +106,7 @@ func Test_Reconcile(t *testing.T) {
 					},
 				},
 			},
-			getInstanceTimes:    1,
+			getInstanceTimes:    2,
 			patchInstanceTimes:  0,
 			deleteInstanceTimes: 1,
 			expectedResult: ctrl.Result{
@@ -135,7 +136,7 @@ func Test_Reconcile(t *testing.T) {
 					},
 				},
 			},
-			getInstanceTimes:    1,
+			getInstanceTimes:    2,
 			patchInstanceTimes:  1,
 			deleteInstanceTimes: 1,
 			expectedResult: ctrl.Result{
@@ -165,7 +166,7 @@ func Test_Reconcile(t *testing.T) {
 					},
 				},
 			},
-			getInstanceTimes:    1,
+			getInstanceTimes:    2,
 			patchInstanceTimes:  1,
 			deleteInstanceTimes: 1,
 			expectedResult: ctrl.Result{
@@ -187,7 +188,6 @@ func Test_Reconcile(t *testing.T) {
 
 			mockedClient.EXPECT().
 				Get(gomock.Any(), gomock.Any(), gomock.Any()).
-				SetArg(2, tc.inst).
 				MaxTimes(tc.getInstanceTimes)
 
 			mockedClient.EXPECT().

--- a/controller/postgres/reconciler_test.go
+++ b/controller/postgres/reconciler_test.go
@@ -200,8 +200,14 @@ func Test_Reconcile(t *testing.T) {
 			// Assert that the composite finalizers are as expected
 			resultComposite := &vshnv1.XVSHNPostgreSQL{}
 			getObjectToAssert(t, resultComposite, fclient, client.ObjectKeyFromObject(&tc.inst))
+
+			// Assert that the namespace also has the finalizers
+			resultNs := &corev1.Namespace{}
+			getObjectToAssert(t, resultNs, fclient, client.ObjectKey{Name: tc.instanceNamespace})
+
 			if tc.expectFinalizer {
 				assert.Contains(t, resultComposite.GetFinalizers(), finalizerName)
+				assert.Contains(t, resultNs.GetFinalizers(), finalizerName)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

* If the instance namespace is deleted, then the controller will disable the deletion protection on the composite

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
