### PR TITLE
Fix leaked backups

### DIFF
--- a/pkg/apiserver/vshn/postgres/vshnpostgresql.go
+++ b/pkg/apiserver/vshn/postgres/vshnpostgresql.go
@@ -27,6 +27,11 @@ func (k *kubeXVSHNPostgresqlProvider) ListXVSHNPostgreSQL(ctx context.Context, n
 	err := k.Client.List(ctx, list)
 	cleanedList := make([]vshnv1.XVSHNPostgreSQL, 0)
 	for _, p := range list.Items {
+		// In some cases instance namespaces is missing and as a consequence all backups from the whole cluster
+		// are being exposed creating a security issue - check APPCAT-563.
+		if p.Status.InstanceNamespace == "" {
+			continue
+		}
 		if p.Labels[claimNamespaceLabel] == "" || p.Labels[claimNameLabel] == "" {
 			continue
 		}

--- a/pkg/apiserver/vshn/postgres/vshnpostgresql_test.go
+++ b/pkg/apiserver/vshn/postgres/vshnpostgresql_test.go
@@ -21,22 +21,23 @@ func Test_ListXVSHNPostgreSQL(t *testing.T) {
 			namespace: "namespace-prod",
 			postgresqls: &vshnv1.XVSHNPostgreSQLList{
 				Items: []vshnv1.XVSHNPostgreSQL{
-					getInstance("prod", "namespace-prod"),
-					getInstance("prod-2", "namespace-prod-2"),
+					getInstance("prod", "namespace-prod", "instance-namespace"),
+					getInstance("prod-2", "namespace-prod-2", "instance-namespace"),
 					getInstanceWithoutLabels("prod-3"),
 					getInstanceWithoutLabels("prod"),
 					getInstanceWithoutClaimName("prod", "namespace-prod"),
 					getInstanceWithoutClaimName("prod-3", "namespace-prod-2"),
 					getInstanceWithoutClaimNamespace("prod"),
 					getInstanceWithoutClaimNamespace("prod-3"),
-					getInstance("test", "namespace-test-2"),
-					getInstance("test", "namespace-prod"),
+					getInstance("test", "namespace-test-2", "instance-namespace"),
+					getInstance("test", "namespace-prod", "instance-namespace"),
+					getInstanceWithoutInstanceNamespace("test", "namespace-prod"),
 				},
 			},
 			expectedPostgresqls: &vshnv1.XVSHNPostgreSQLList{
 				Items: []vshnv1.XVSHNPostgreSQL{
-					getInstance("prod", "namespace-prod"),
-					getInstance("test", "namespace-prod"),
+					getInstance("prod", "namespace-prod", "instance-namespace"),
+					getInstance("test", "namespace-prod", "instance-namespace"),
 				},
 			},
 		},
@@ -44,16 +45,17 @@ func Test_ListXVSHNPostgreSQL(t *testing.T) {
 			namespace: "namespace-not-match",
 			postgresqls: &vshnv1.XVSHNPostgreSQLList{
 				Items: []vshnv1.XVSHNPostgreSQL{
-					getInstance("prod", "namespace-prod"),
-					getInstance("prod-2", "namespace-prod-2"),
+					getInstance("prod", "namespace-prod", "instance-namespace"),
+					getInstance("prod", "namespace-prod", "instance-namespace"),
+					getInstance("prod-2", "namespace-prod-2", "instance-namespace"),
 					getInstanceWithoutLabels("prod-3"),
 					getInstanceWithoutLabels("prod"),
 					getInstanceWithoutClaimName("prod", "namespace-prod"),
 					getInstanceWithoutClaimName("prod-3", "namespace-prod-2"),
 					getInstanceWithoutClaimNamespace("prod"),
 					getInstanceWithoutClaimNamespace("prod-3"),
-					getInstance("test", "namespace-test-2"),
-					getInstance("test", "namespace-prod"),
+					getInstance("test", "namespace-test-2", "instance-namespace"),
+					getInstance("test", "namespace-prod", "instance-namespace"),
 				},
 			},
 			expectedPostgresqls: &vshnv1.XVSHNPostgreSQLList{
@@ -118,7 +120,7 @@ func getInstanceWithoutLabels(name string) vshnv1.XVSHNPostgreSQL {
 	}
 }
 
-func getInstance(name, namespace string) vshnv1.XVSHNPostgreSQL {
+func getInstanceWithoutInstanceNamespace(name, namespace string) vshnv1.XVSHNPostgreSQL {
 	return vshnv1.XVSHNPostgreSQL{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name + "-tty",
@@ -126,6 +128,21 @@ func getInstance(name, namespace string) vshnv1.XVSHNPostgreSQL {
 				claimNameLabel:      name,
 				claimNamespaceLabel: namespace,
 			},
+		},
+	}
+}
+
+func getInstance(name, namespace, instanceNamespace string) vshnv1.XVSHNPostgreSQL {
+	return vshnv1.XVSHNPostgreSQL{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name + "-tty",
+			Labels: map[string]string{
+				claimNameLabel:      name,
+				claimNamespaceLabel: namespace,
+			},
+		},
+		Status: vshnv1.VSHNPostgreSQLStatus{
+			InstanceNamespace: instanceNamespace,
 		},
 	}
 }

--- a/pkg/apiserver/vshn/redis/vshnredis.go
+++ b/pkg/apiserver/vshn/redis/vshnredis.go
@@ -24,5 +24,16 @@ func (c *concreteRedisProvider) ListVSHNRedis(ctx context.Context, namespace str
 		return nil, err
 	}
 
+	cleanedList := make([]vshnv1.VSHNRedis, 0)
+	for _, p := range instances.Items {
+		//
+		// In some cases instance namespaces is missing and as a consequence all backups from the whole cluster
+		// are being exposed creating a security issue - check APPCAT-563.
+		if p.Status.InstanceNamespace != "" {
+			cleanedList = append(cleanedList, p)
+		}
+	}
+	instances.Items = cleanedList
+
 	return instances, nil
 }


### PR DESCRIPTION
All backups in the cluster are being leaked due to APPCAT-563. Here we make sure to filter out all Custom Resources that do not have an InstanceNamespace. Having an empty InstanceNamespace will leak all backups later on in the business logic.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
